### PR TITLE
[ISSUE-23] Implement Union Method

### DIFF
--- a/src/mezages.py
+++ b/src/mezages.py
@@ -97,12 +97,12 @@ class Mezages:
         self.__is_path(mount_path)
 
         # if the mount_path exist, arrange the path accordingly
-        adjusted_store = {f"{mount_path}.{path}" if mount_path else path: sack for path, sack in store.items()}
+        adjusted_store = {f"{mount_path}.{path}" if mount_path else path: bucket for path, bucket in store.items()}
 
-        for path, sack in adjusted_store.items():
+        for path, bucket in adjusted_store.items():
             if path in self.__store:
                 # unify the bucket if path already exist
-                self.__store[path] = self.__store[path].union(sack)
+                self.__store[path] = self.__store[path].union(bucket)
             else:
                 # copy path and bucket into the instance
-                self.__store[path] = set(sack)
+                self.__store[path] = set(bucket)

--- a/src/mezages.py
+++ b/src/mezages.py
@@ -99,11 +99,10 @@ class Mezages:
         # if the mount_path exist, arrange the path accordingly
         adjusted_store = {f"{mount_path}.{path}" if mount_path else path: sack for path, sack in store.items()}
 
-        # iterate through the adjusted store, and unify with the existing paths instance
         for path, sack in adjusted_store.items():
             if path in self.__store:
-                # unify the sack if path already exist
+                # unify the bucket if path already exist
                 self.__store[path] = self.__store[path].union(sack)
             else:
-                # copy path and sack into the instance
+                # copy path and bucket into the instance
                 self.__store[path] = set(sack)

--- a/src/mezages.py
+++ b/src/mezages.py
@@ -90,3 +90,20 @@ class Mezages:
         raise MezagesError('\n'.join([
             'Encountered some store issues\n', *[f'\t[!] {failure}' for failure in failures], '',
         ]))
+
+    def union(self, store: MezagesInputStore, mount_path: str | None = None) -> None:
+        # validate arguments
+        self.__ensure_store(store)
+        self.__is_path(mount_path)
+
+        # if the mount_path exist, arrange the path accordingly
+        adjusted_store = {f"{mount_path}.{path}" if mount_path else path: sack for path, sack in store.items()}
+
+        # iterate through the adjusted store, and unify with the existing paths instance
+        for path, sack in adjusted_store.items():
+            if path in self.__store:
+                # unify the sack if path already exist
+                self.__store[path] = self.__store[path].union(sack)
+            else:
+                # copy path and sack into the instance
+                self.__store[path] = set(sack)

--- a/tests/test_mezages.py
+++ b/tests/test_mezages.py
@@ -215,3 +215,25 @@ class TestUnionMethod(TestCase):
         }
 
         self.assertDictEqual(self.message.map, expected_result)
+
+    def test_union_with_empty_store(self):
+        '''it should handle an empty mount point without raising error'''
+
+        # Call union with a non-empty store and an empty mount path
+        self.message.union({
+            base_path: [f'{subject_placeholder} must contain only 5 characters'],
+            'gender': {f'{subject_placeholder} is not a valid gender string'},
+            'data.email': (
+                f'{subject_placeholder} is not a valid email address',
+                f'{subject_placeholder} must have the Gmail domain'
+            ),
+        }, mount_path='')
+
+        # ensures that the original message map remains unchanged
+        expected_result = {
+            'base': ['{entity} must contain only 5 characters', '{entity} must be a string'],
+            'data.email': ['{entity} must have the Gmail domain', '{entity} is not a valid email address'],
+            'gender': ['{entity} is not a valid gender string']
+        }
+
+        self.assertDictEqual(self.message.map, expected_result)

--- a/tests/test_mezages.py
+++ b/tests/test_mezages.py
@@ -149,49 +149,69 @@ class TestPropertiesAndMethods(TestCase):
         self.assertTrue("[!] '{base}' is not mapped to a valid bucket of messages" in exception_message)
         self.assertTrue("[!] 'data.email' has one or more invalid messages in its bucket" in exception_message)
 
-    def test_union_without_mount_point(self):
-        '''it unifies messages from the store without a mount point'''
 
-        self.mezages.union({
+class TestUnionMethod(TestCase):
+    '''when calling a method on the instance messages'''
+
+    def setUp(self):
+        self.message = Mezages({
+            base_path: [f'{subject_placeholder} must contain only 5 characters'],
+            'gender': {f'{subject_placeholder} is not a valid gender string'},
+            'data.email': (
+                f'{subject_placeholder} must have the gmail domain',
+                f'{subject_placeholder} is not a valid email address',
+            ),
+        })
+
+    def test_union_with_mount_point(self):
+        '''it unifies from store with a mount point'''
+
+        self.message.union({
             base_path: [f'{subject_placeholder} must contain only 5 characters'],
             'gender': {f'{subject_placeholder} is not a valid gender string'},
             'data.email': (
                 f'{subject_placeholder} is not a valid email address',
                 f'{subject_placeholder} must have the Gmail domain'
             ),
-        })
+        }, mount_path='user')
 
-        self.assertEqual(self.mezages.map, {
-            base_path: [
-                f'{subject_placeholder} must be a string',
-                f'{subject_placeholder} must contain only 5 characters'
-            ],
-            'gender': [f'{subject_placeholder} is not a valid gender string'],
+        expected_result = {
+            '{base}': ['Must contain only 5 characters'],
+            'gender': ['gender is not a valid gender string'],
             'data.email': [
-                f'{subject_placeholder} is not a valid email address',  # Duplicates of this message were removed
-                f'{subject_placeholder} must have the Gmail domain'
+                'data.email must have the gmail domain',
+                'data.email is not a valid email address'
             ],
-        })
+            'user.{base}': ['user.{base} must contain only 5 characters'],
+            'user.gender': ['user.gender is not a valid gender string'],
+            'user.data.email': [
+                'user.data.email is not a valid email address',
+                'user.data.email must have the Gmail domain'
+            ],
+        }
 
-    def test_union_with_mount_point(self):
-        '''it unifies the messages from store with mount point'''
+        self.assertDictEqual(self.message.map, expected_result)
 
-        self.mezages.union({
-            base_path: [f'{subject_placeholder} must contain only 3 characters'],
+    def test_union_without_mount_point(self):
+        '''it unifies messages from store without a mount point'''
+
+        self.message.union({
+            base_path: [f'{subject_placeholder} must contain only 5 characters'],
             'gender': {f'{subject_placeholder} is not a valid gender string'},
             'data.email': (
                 f'{subject_placeholder} is not a valid email address',
-                f'{subject_placeholder} must have the Yahoo domain',
-            ),
-        }, mount_path='user')
-
-        self.assertEqual(self.mezages.map, {
-            'base': [f'{subject_placeholder} must be a string'],
-            'data.email': [f'{subject_placeholder} is not a valid email address'],
-            'user': [f'{subject_placeholder} must contain only 5 characters'],
-            'user.gender': [f'{subject_placeholder} is not a valid gender string'],
-            'user.data.email': [
-                f'{subject_placeholder} is not a valid email address',
                 f'{subject_placeholder} must have the Gmail domain'
+            ),
+        }, mount_path=None)
+
+        expected_result = {
+            '{base}': ['Must contain only 5 characters'],
+            'gender': ['gender is not a valid gender string'],
+            'data.email': [
+                'data.email must have the gmail domain',
+                'data.email is not a valid email address',
+                'data.email must have the Gmail domain'
             ],
-        })
+        }
+
+        self.assertDictEqual(self.message.map, expected_result)

--- a/tests/test_mezages.py
+++ b/tests/test_mezages.py
@@ -148,3 +148,50 @@ class TestPropertiesAndMethods(TestCase):
         # For example, incompletely defined error messages provided here wil still make the assertions pass
         self.assertTrue("[!] '{base}' is not mapped to a valid bucket of messages" in exception_message)
         self.assertTrue("[!] 'data.email' has one or more invalid messages in its bucket" in exception_message)
+
+    def test_union_without_mount_point(self):
+        '''it unifies messages from the store without a mount point'''
+
+        self.mezages.union({
+            base_path: [f'{subject_placeholder} must contain only 5 characters'],
+            'gender': {f'{subject_placeholder} is not a valid gender string'},
+            'data.email': (
+                f'{subject_placeholder} is not a valid email address',
+                f'{subject_placeholder} must have the Gmail domain'
+            ),
+        })
+
+        self.assertEqual(self.mezages.map, {
+            base_path: [
+                f'{subject_placeholder} must be a string',
+                f'{subject_placeholder} must contain only 5 characters'
+            ],
+            'gender': [f'{subject_placeholder} is not a valid gender string'],
+            'data.email': [
+                f'{subject_placeholder} is not a valid email address',  # Duplicates of this message were removed
+                f'{subject_placeholder} must have the Gmail domain'
+            ],
+        })
+
+    def test_union_with_mount_point(self):
+        '''it unifies the messages from store with mount point'''
+
+        self.mezages.union({
+            base_path: [f'{subject_placeholder} must contain only 3 characters'],
+            'gender': {f'{subject_placeholder} is not a valid gender string'},
+            'data.email': (
+                f'{subject_placeholder} is not a valid email address',
+                f'{subject_placeholder} must have the Yahoo domain',
+            ),
+        }, mount_path='user')
+
+        self.assertEqual(self.mezages.map, {
+            'base': [f'{subject_placeholder} must be a string'],
+            'data.email': [f'{subject_placeholder} is not a valid email address'],
+            'user': [f'{subject_placeholder} must contain only 5 characters'],
+            'user.gender': [f'{subject_placeholder} is not a valid gender string'],
+            'user.data.email': [
+                f'{subject_placeholder} is not a valid email address',
+                f'{subject_placeholder} must have the Gmail domain'
+            ],
+        })


### PR DESCRIPTION
Implemented a `union` method to unify a store with the current `Mezages` instance.
- Added the `union` method to the `Mezages` class.
- Implemented validation for `store` and `mount_path` arguments.
- Copied paths and their message bucket from the store into the current (`self.__store`)
- Unify buckets if a path in the `store` already exists in the current instance, considering the `mount_path`.
