### PR TITLE
[ISSUES-10] Implement substitute subject for record types

### DIFF
--- a/src/mezages/subjects.py
+++ b/src/mezages/subjects.py
@@ -67,8 +67,10 @@ def get_subject_substitute(path: str, state: 'State') -> Optional[str]:
         return None
 
     if subject_parent_type == 'record':
-        key = path.split('.')[-1]
-        parent_path = '.'.join(path.split('.')[:-1])
-        return f'{key} in {parent_path}' if parent_path else key
+        tokens = path.split('.')
+        parent_type = '.'.join(tokens[:-1])
+        prop = tokens[-1].strip('{').strip('}')
+
+        return f'{prop} in {parent_type}' if parent_type else prop
 
     return path

--- a/src/mezages/subjects.py
+++ b/src/mezages/subjects.py
@@ -66,15 +66,9 @@ def get_subject_substitute(path: str, state: 'State') -> Optional[str]:
     if not subject_type and not subject_parent_type:
         return None
 
-    # Add better array subject substitute logic here
-
     if subject_parent_type == 'record':
-        key = path.split('.')[-1]  # extract the key from the path
-        parent_path = '.'.join(path.split('.')[:-1])  # get the parent path
-
-        if parent_path:
-            return f'{key} in {parent_path}'  # use <key> in <parent-path>
-        else:
-            return key  # if no parent use <key>
+        key = path.split('.')[-1]
+        parent_path = '.'.join(path.split('.')[:-1])
+        return f'{key} in {parent_path}' if parent_path else key
 
     return path

--- a/src/mezages/subjects.py
+++ b/src/mezages/subjects.py
@@ -67,5 +67,14 @@ def get_subject_substitute(path: str, state: 'State') -> Optional[str]:
         return None
 
     # Add better array subject substitute logic here
-    # Add better record subject substitute logic here
+
+    if subject_parent_type == 'record':
+        key = path.split('.')[-1]  # extract the key from the path
+        parent_path = '.'.join(path.split('.')[:-1])  # get the parent path
+
+        if parent_path:
+            return f'{key} in {parent_path}'  # use <key> in <parent-path>
+        else:
+            return key  # if no parent use <key>
+
     return path

--- a/tests/test_subjects.py
+++ b/tests/test_subjects.py
@@ -59,6 +59,6 @@ class TestSubjects(BaseCase):
 
         self.assertEqual(get_subject_substitute(ROOT_PATH, self.state), None)
         self.assertEqual(get_subject_substitute('user', self.state), 'user')
-        self.assertEqual(get_subject_substitute('user.{name}', self.state), 'user.{name}')
-        self.assertEqual(get_subject_substitute('user.{roles}', self.state), 'user.{roles}')
+        self.assertEqual(get_subject_substitute('user.{name}', self.state), '{name} in user')
+        self.assertEqual(get_subject_substitute('user.{roles}', self.state), '{roles} in user')
         self.assertEqual(get_subject_substitute('user.{roles}.[0]', self.state), 'user.{roles}.[0]')

--- a/tests/test_subjects.py
+++ b/tests/test_subjects.py
@@ -59,6 +59,6 @@ class TestSubjects(BaseCase):
 
         self.assertEqual(get_subject_substitute(ROOT_PATH, self.state), None)
         self.assertEqual(get_subject_substitute('user', self.state), 'user')
-        self.assertEqual(get_subject_substitute('user.{name}', self.state), '{name} in user')
-        self.assertEqual(get_subject_substitute('user.{roles}', self.state), '{roles} in user')
+        self.assertEqual(get_subject_substitute('user.{name}', self.state), 'name in user')
+        self.assertEqual(get_subject_substitute('user.{roles}', self.state), 'roles in user')
         self.assertEqual(get_subject_substitute('user.{roles}.[0]', self.state), 'user.{roles}.[0]')


### PR DESCRIPTION
- Subject substitute now includes parent path for record types (e.g., "name in user" instead of "user.{name}").
- Updated tests to reflect new behavior.