### PR TITLE
[ISSUES-40] Implement mount method for Sack class (#40)

### DIFF
--- a/src/mezages/sack.py
+++ b/src/mezages/sack.py
@@ -47,3 +47,21 @@ class Sack:
 
             previous_bucket = self.__state.get(new_path, set())
             self.__state[new_path] = previous_bucket.union(bucket)
+
+    def mount(self, path: str) -> None:
+
+        ensure_path(path)
+
+        new_state = {}
+
+        for old_path, bucket in self.__state.items():
+            new_path = old_path
+
+            if new_path == ROOT_PATH or path == ROOT_PATH:
+                new_path = path
+            else:
+                new_path = f'{path}.{old_path}'
+
+            new_state[new_path] = bucket
+
+        self.__state = new_state

--- a/src/mezages/sack.py
+++ b/src/mezages/sack.py
@@ -57,7 +57,7 @@ class Sack:
         for old_path, bucket in self.__state.items():
             new_path = old_path
 
-            if new_path == ROOT_PATH or path == ROOT_PATH:
+            if new_path == ROOT_PATH:
                 new_path = path
             else:
                 new_path = f'{path}.{old_path}'

--- a/tests/test_sack.py
+++ b/tests/test_sack.py
@@ -178,3 +178,37 @@ class TestMerge(BaseCase):
                 f'{SUBJECT_PLACEHOLDER} must be registered',
             }
         })
+
+
+class TestMount(BaseCase):
+    '''when mounting a path to a sack state'''
+
+    def setUp(self):
+        self.sack = Sack({
+            ROOT_PATH: [f'{SUBJECT_PLACEHOLDER} must contain only 5 chars'],
+            'gender': {f'{SUBJECT_PLACEHOLDER} is not a valid gender'},
+            'data.{email}': ('This is not a valid email address',)
+        })
+
+    def test_mount_renames_root_path(self):
+        '''it renames the root path'''
+
+        self.sack.mount('user')
+
+        self.assertEqual(self.sack.map, {
+            'user': ['Must contain only 5 chars'],
+            'user.gender': ['Is not a valid gender'],
+            'user.data.{email}': ['This is not a valid email address'],
+        }
+        )
+
+    def test_mount_prefixes_child_path(self):
+        '''it prefixes the child path with the root path'''
+
+        self.sack.mount('dataset')
+
+        self.assertEqual(self.sack.map, {
+            'dataset': ['Must contain only 5 chars'],
+            'dataset.gender': ['Is not a valid gender'],
+            'dataset.data.{email}': ['This is not a valid email address']}
+        )


### PR DESCRIPTION
*Description*

This PR introduces the mount method to the `Sack class`, enabling the mounting of a sack's state at a specified path. It fulfills the following requirements:
- Renames the root path to a mount path.
- Prefixes child paths with the mount path.
- Prefixes all child paths even when no root path exists.