### PR TITLE
[ISSUE-24] Implement Add Messages Method

### DIFF
--- a/src/mezages/sack.py
+++ b/src/mezages/sack.py
@@ -2,7 +2,7 @@ from copy import deepcopy
 from typing import Any, Optional
 from mezages.paths import ensure_path, ROOT_PATH
 from mezages.subjects import get_subject_substitute
-from mezages.buckets import FormattedBucket, format_bucket
+from mezages.buckets import FormattedBucket, ensure_bucket, format_bucket, Bucket
 from mezages.states import State, ensure_state, FormattedState
 
 
@@ -65,3 +65,12 @@ class Sack:
             new_state[new_path] = bucket
 
         self.__state = new_state
+
+    def add_messages(self, path: str, messages: Bucket) -> None:
+        path = ensure_path(path)
+        messages = ensure_bucket(messages)
+
+        if path in self.__state:
+            self.__state[path] = self.__state[path].union(messages)
+        else:
+            self.__state[path] = messages

--- a/tests/test_sack.py
+++ b/tests/test_sack.py
@@ -22,7 +22,7 @@ class TestInit(BaseCase):
             'gender': {f'{SUBJECT_PLACEHOLDER} is not a valid gender string'},
             'data.email': (
                 f'{SUBJECT_PLACEHOLDER} is not a valid email address',
-                f'{SUBJECT_PLACEHOLDER} must have the gmail domain'
+                f'{SUBJECT_PLACEHOLDER} must have the gmail domain',
             ),
         }
 
@@ -33,32 +33,39 @@ class TestInit(BaseCase):
         '''it raises a state error when an invalid init state is provided'''
 
         with self.assertRaises(StateError) as error:
-            Sack({
-                ROOT_PATH: 'some invalid message bucket',
-                'gender': {f'{SUBJECT_PLACEHOLDER} is not a valid gender string'},
-                'data.email': (5, f'{SUBJECT_PLACEHOLDER} must have the gmail domain'),
-            })
+            Sack(
+                {
+                    ROOT_PATH: 'some invalid message bucket',
+                    'gender': {f'{SUBJECT_PLACEHOLDER} is not a valid gender string'},
+                    'data.email': (5, f'{SUBJECT_PLACEHOLDER} must have the gmail domain'),
+                }
+            )
 
         failures = error.exception.data['failures']
 
-        self.assertCountEqual(failures, {
-            "'data.email' is mapped to an invalid bucket",
-            f'{repr(ROOT_PATH)} is mapped to an invalid bucket',
-        })
+        self.assertCountEqual(
+            failures,
+            {
+                "'data.email' is mapped to an invalid bucket",
+                f'{repr(ROOT_PATH)} is mapped to an invalid bucket',
+            },
+        )
 
 
 class TestProperties(BaseCase):
     '''when accessing properties on sack instances'''
 
     def setUp(self):
-        self.sack = Sack({
-            ROOT_PATH: [f'{SUBJECT_PLACEHOLDER} must contain only 5 characters'],
-            'gender': {f'{SUBJECT_PLACEHOLDER} is not a valid gender string'},
-            'data.{email}': (
-                f'{SUBJECT_PLACEHOLDER} must have the gmail domain',
-                f'{SUBJECT_PLACEHOLDER} is not a valid email address',
-            ),
-        })
+        self.sack = Sack(
+            {
+                ROOT_PATH: [f'{SUBJECT_PLACEHOLDER} must contain only 5 characters'],
+                'gender': {f'{SUBJECT_PLACEHOLDER} is not a valid gender string'},
+                'data.{email}': (
+                    f'{SUBJECT_PLACEHOLDER} must have the gmail domain',
+                    f'{SUBJECT_PLACEHOLDER} is not a valid email address',
+                ),
+            }
+        )
 
     def test_the_state_property(self):
         '''it returns a copy of the private state within a sack'''
@@ -72,64 +79,81 @@ class TestProperties(BaseCase):
     def test_the_all_property(self):
         '''it returns a flat list of formatted messages for an entire sack'''
 
-        self.assertCountEqual(self.sack.all, [
-            'Must contain only 5 characters',
-            'Is not a valid gender string',
-            'data.{email} must have the gmail domain',
-            'data.{email} is not a valid email address',
-        ])
+        self.assertCountEqual(
+            self.sack.all,
+            [
+                'Must contain only 5 characters',
+                'Is not a valid gender string',
+                'data.{email} must have the gmail domain',
+                'data.{email} is not a valid email address',
+            ],
+        )
 
     def test_the_map_property(self):
         '''it returns a dict of paths to lists of formatted messages for an entire sack'''
 
-        return self.assertDictDeepEqual(self.sack.map, {
-            ROOT_PATH: ['Must contain only 5 characters'],
-            'gender': ['Is not a valid gender string'],
-            'data.{email}': [
-                'data.{email} must have the gmail domain',
-                'data.{email} is not a valid email address',
-            ],
-        })
+        return self.assertDictDeepEqual(
+            self.sack.map,
+            {
+                ROOT_PATH: ['Must contain only 5 characters'],
+                'gender': ['Is not a valid gender string'],
+                'data.{email}': [
+                    'data.{email} must have the gmail domain',
+                    'data.{email} is not a valid email address',
+                ],
+            },
+        )
 
 
 class TestMerge(BaseCase):
     '''when merging a state with a sack state'''
 
     def setUp(self):
-        self.sack = Sack({
-            ROOT_PATH: [f'{SUBJECT_PLACEHOLDER} must contain only 5 chars'],
-            'gender': {f'{SUBJECT_PLACEHOLDER} is not a valid gender'},
-            'data.{email}': ('This is not a valid email address',)
-        })
+        self.sack = Sack(
+            {
+                ROOT_PATH: [f'{SUBJECT_PLACEHOLDER} must contain only 5 chars'],
+                'gender': {f'{SUBJECT_PLACEHOLDER} is not a valid gender'},
+                'data.{email}': ('This is not a valid email address',),
+            }
+        )
 
     def test_with_empty_state(self):
         '''it leaves the sack state unchanged'''
 
         self.sack.merge(dict())
 
-        self.assertDictDeepEqual(self.sack.state, {
-            ROOT_PATH: {f'{SUBJECT_PLACEHOLDER} must contain only 5 chars'},
-            'gender': {f'{SUBJECT_PLACEHOLDER} is not a valid gender'},
-            'data.{email}': {'This is not a valid email address'},
-        })
+        self.assertDictDeepEqual(
+            self.sack.state,
+            {
+                ROOT_PATH: {f'{SUBJECT_PLACEHOLDER} must contain only 5 chars'},
+                'gender': {f'{SUBJECT_PLACEHOLDER} is not a valid gender'},
+                'data.{email}': {'This is not a valid email address'},
+            },
+        )
 
     def test_with_invalid_state(self):
         '''it raises an error with validation failures'''
 
-        invalid_state = cast(State, {
-            ROOT_PATH: 'some invalid message bucket',
-            'data.email': (5, 'Must have the gmail domain'),
-        })
+        invalid_state = cast(
+            State,
+            {
+                ROOT_PATH: 'some invalid message bucket',
+                'data.email': (5, 'Must have the gmail domain'),
+            },
+        )
 
         with self.assertRaises(StateError) as error:
             self.sack.merge(invalid_state)
 
         failures = error.exception.data['failures']
 
-        self.assertCountEqual(failures, {
-            "'data.email' is mapped to an invalid bucket",
-            f'{repr(ROOT_PATH)} is mapped to an invalid bucket',
-        })
+        self.assertCountEqual(
+            failures,
+            {
+                "'data.email' is mapped to an invalid bucket",
+                f'{repr(ROOT_PATH)} is mapped to an invalid bucket',
+            },
+        )
 
     def test_with_invalid_mount_path(self):
         '''it raises an error about the invalid mount path'''
@@ -143,64 +167,80 @@ class TestMerge(BaseCase):
     def test_with_no_mount_path(self):
         '''it merges state into sack with child paths unprefixed'''
 
-        new_state = cast(State, {
-            ROOT_PATH: ['This is a complete message for root subject'],
-            'data.{name}': {f'{SUBJECT_PLACEHOLDER} must be a string value'},
-        })
+        new_state = cast(
+            State,
+            {
+                ROOT_PATH: ['This is a complete message for root subject'],
+                'data.{name}': {f'{SUBJECT_PLACEHOLDER} must be a string value'},
+            },
+        )
 
         self.sack.merge(new_state)
 
-        self.assertDictDeepEqual(self.sack.state, {
-            ROOT_PATH: {
-                'This is a complete message for root subject',
-                f'{SUBJECT_PLACEHOLDER} must contain only 5 chars'
+        self.assertDictDeepEqual(
+            self.sack.state,
+            {
+                ROOT_PATH: {
+                    'This is a complete message for root subject',
+                    f'{SUBJECT_PLACEHOLDER} must contain only 5 chars',
+                },
+                'gender': {f'{SUBJECT_PLACEHOLDER} is not a valid gender'},
+                'data.{email}': {'This is not a valid email address'},
+                'data.{name}': {f'{SUBJECT_PLACEHOLDER} must be a string value'},
             },
-            'gender': {f'{SUBJECT_PLACEHOLDER} is not a valid gender'},
-            'data.{email}': {'This is not a valid email address'},
-            'data.{name}': {f'{SUBJECT_PLACEHOLDER} must be a string value'},
-        })
+        )
 
     def test_with_mount_path(self):
         '''it merges state into sack with child paths prefixed'''
 
-        new_state = cast(State, {
-            ROOT_PATH: ['This is a complete message for new data'],
-            '{email}': {f'{SUBJECT_PLACEHOLDER} must be registered'},
-        })
+        new_state = cast(
+            State,
+            {
+                ROOT_PATH: ['This is a complete message for new data'],
+                '{email}': {f'{SUBJECT_PLACEHOLDER} must be registered'},
+            },
+        )
 
         self.sack.merge(new_state, 'data')
 
-        self.assertDictDeepEqual(self.sack.state, {
-            ROOT_PATH: {f'{SUBJECT_PLACEHOLDER} must contain only 5 chars'},
-            'data': {'This is a complete message for new data'},
-            'gender': {f'{SUBJECT_PLACEHOLDER} is not a valid gender'},
-            'data.{email}': {
-                'This is not a valid email address',
-                f'{SUBJECT_PLACEHOLDER} must be registered',
-            }
-        })
+        self.assertDictDeepEqual(
+            self.sack.state,
+            {
+                ROOT_PATH: {f'{SUBJECT_PLACEHOLDER} must contain only 5 chars'},
+                'data': {'This is a complete message for new data'},
+                'gender': {f'{SUBJECT_PLACEHOLDER} is not a valid gender'},
+                'data.{email}': {
+                    'This is not a valid email address',
+                    f'{SUBJECT_PLACEHOLDER} must be registered',
+                },
+            },
+        )
 
 
 class TestMount(BaseCase):
     '''when mounting a path to a sack state'''
 
     def setUp(self):
-        self.sack = Sack({
-            ROOT_PATH: [f'{SUBJECT_PLACEHOLDER} must contain only 5 chars'],
-            'gender': {f'{SUBJECT_PLACEHOLDER} is not a valid gender'},
-            'data.{email}': ('This is not a valid email address',)
-        })
+        self.sack = Sack(
+            {
+                ROOT_PATH: [f'{SUBJECT_PLACEHOLDER} must contain only 5 chars'],
+                'gender': {f'{SUBJECT_PLACEHOLDER} is not a valid gender'},
+                'data.{email}': ('This is not a valid email address',),
+            }
+        )
 
     def test_mount_renames_root_path(self):
         '''it renames the root path'''
 
         self.sack.mount('user')
 
-        self.assertEqual(self.sack.map, {
-            'user': ['Must contain only 5 chars'],
-            'user.gender': ['Is not a valid gender'],
-            'user.data.{email}': ['This is not a valid email address'],
-        }
+        self.assertEqual(
+            self.sack.map,
+            {
+                'user': ['Must contain only 5 chars'],
+                'user.gender': ['Is not a valid gender'],
+                'user.data.{email}': ['This is not a valid email address'],
+            },
         )
 
     def test_mount_prefixes_child_path(self):
@@ -208,23 +248,29 @@ class TestMount(BaseCase):
 
         self.sack.mount('dataset')
 
-        self.assertEqual(self.sack.map, {
-            'dataset': ['Must contain only 5 chars'],
-            'dataset.gender': ['Is not a valid gender'],
-            'dataset.data.{email}': ['This is not a valid email address']}
+        self.assertEqual(
+            self.sack.map,
+            {
+                'dataset': ['Must contain only 5 chars'],
+                'dataset.gender': ['Is not a valid gender'],
+                'dataset.data.{email}': ['This is not a valid email address'],
+            },
         )
 
     def test_mount_preserves_substitute(self):
         '''it ensures the subject substitute maintain it path linages'''
 
-        self.instance = Sack({
-            ROOT_PATH: {f'{SUBJECT_PLACEHOLDER} message'},
-            'user.{name}': {'message'},
-        })
+        self.instance = Sack(
+            {
+                ROOT_PATH: {f'{SUBJECT_PLACEHOLDER} message'},
+                'user.{name}': {'message'},
+            }
+        )
         self.instance.mount('data')
 
-        self.assertEqual(get_subject_substitute(
-            'data.user.{name}', self.instance.state), 'Name in data.user')
+        self.assertEqual(
+            get_subject_substitute('data.user.{name}', self.instance.state), 'Name in data.user'
+        )
 
     def test_mount_handle_invalid_path(self):
         '''it raises error with validation failure'''
@@ -241,8 +287,78 @@ class TestMount(BaseCase):
 
         self.sack.mount('%root%')
 
-        self.assertEqual(self.sack.map, {
-            '%root%': ['Must contain only 5 chars'],
-            '%root%.gender': ['Is not a valid gender'],
-            '%root%.data.{email}': ['This is not a valid email address']
-        })
+        self.assertEqual(
+            self.sack.map,
+            {
+                '%root%': ['Must contain only 5 chars'],
+                '%root%.gender': ['Is not a valid gender'],
+                '%root%.data.{email}': ['This is not a valid email address'],
+            },
+        )
+
+
+class TestNewMessage(BaseCase):
+    '''when adding a new message to a sack state'''
+
+    def setUp(self) -> None:
+        self.sack = Sack()
+
+    def test_add_new_messages(self):
+        '''it adds new messages specific to a path to the sack'''
+        self.sack.add_messages(
+            'data.{email}',
+            {'This is not a valid email address', f'{SUBJECT_PLACEHOLDER} must be registered'},
+        )
+
+        self.assertEqual(
+            self.sack.map,
+            {
+                'data.{email}': [
+                    'Email in data must be registered',
+                    'This is not a valid email address',
+                ]
+            },
+        )
+
+    def test_add_messages_to_empty_path(self):
+        '''it raises PathError with an invalid path input argument'''
+
+        with self.assertRaises(PathError) as error:
+            self.sack.add_messages('', {'Must contain only 5 chars'})
+
+        expected_message = "'' is an invalid path"
+
+        self.assertEqual(str(error.exception), expected_message)
+
+    def test_add_messages_to_new_path(self):
+        '''it creates a new message for a path'''
+        self.sack.add_messages('username', {'New message'})
+
+        self.assertEqual(
+            self.sack.map,
+            {
+                'username': ['New message'],
+            },
+        )
+
+    def test_add_messages_with_duplicates(self):
+        '''it adds unique messages and ignores duplicates'''
+
+        self.sack.add_messages(
+            'data.{email}',
+            {'This is not a valid email address', f'{SUBJECT_PLACEHOLDER} must be registered'},
+        )
+        self.sack.add_messages(
+            'data.{email}',
+            {'This is not a valid email address', f'{SUBJECT_PLACEHOLDER} must be registered'},
+        )
+
+        self.assertEqual(
+            self.sack.map,
+            {
+                'data.{email}': [
+                    'Email in data must be registered',
+                    'This is not a valid email address',
+                ]
+            },
+        )


### PR DESCRIPTION
**Changes:**

- Added the `add_message` method that takes a `path` and a bucket of `messages` as arguments.
- Validates the input `path` using `ensure_path`.
- Ensures the provided messages are in a valid bucket format using `ensure_bucket`.
- If the path already exists in the state, combine the new messages with the existing ones using `union`.
- Otherwise, add the new messages as a new entry in the `state` using the provided `path`.