### PR TITLE
[ISSUE-62] Implement Merge Method

### DIFF
--- a/src/mezages/sack.py
+++ b/src/mezages/sack.py
@@ -1,6 +1,6 @@
 from copy import deepcopy
 from itertools import chain
-from typing import Optional, Sequence
+from typing import Self, Optional, Sequence
 
 from mezages.lib import (
     Message,
@@ -71,19 +71,17 @@ class Sack:
             self.__store[context_path].setdefault(message['kind'], list())
             self.__store[context_path][message['kind']].append(message)
 
-    def merge(self, other: 'Sack', mount_context_path: Optional[str] = None) -> None:
-
-        mount_context_path = ensure_context_path(mount_context_path)
+    def merge(self, other: Self, mount_context_path: Optional[str] = None) -> None:
 
         for context_path, context_store in other.store.items():
-            merged_context_path = (
-                f'{mount_context_path}.{context_path}'
-                if context_path
-                else mount_context_path
+            new_context_path = (
+                mount_context_path if mount_context_path else GLOBAL_CONTEXT_PATH
             )
 
-            self.__store.setdefault(merged_context_path, dict())
+            if context_path != GLOBAL_CONTEXT_PATH:
+                new_context_path += f'.{context_path}'
+
+            self.__store.setdefault(new_context_path, dict())
 
             for kind, messages in context_store.items():
-                self.__store[merged_context_path].setdefault(kind, list())
-                self.__store[merged_context_path][kind].extend(messages)
+                self.__store[new_context_path].setdefault(kind, list()).extend(messages)

--- a/src/mezages/sack.py
+++ b/src/mezages/sack.py
@@ -72,16 +72,15 @@ class Sack:
             self.__store[context_path][message['kind']].append(message)
 
     def merge(self, other: Self, mount_context_path: Optional[str] = None) -> None:
-
         for context_path, context_store in other.store.items():
             new_context_path = (
-                mount_context_path if mount_context_path else GLOBAL_CONTEXT_PATH
+                context_path
+                if mount_context_path in [None, GLOBAL_CONTEXT_PATH]
+                else f'{mount_context_path}.{context_path}'
             )
-
-            if context_path != GLOBAL_CONTEXT_PATH:
-                new_context_path += f'.{context_path}'
 
             self.__store.setdefault(new_context_path, dict())
 
             for kind, messages in context_store.items():
-                self.__store[new_context_path].setdefault(kind, list()).extend(messages)
+                self.__store[new_context_path].setdefault(kind, list())
+                self.__store[new_context_path][kind] += messages

--- a/src/mezages/sack.py
+++ b/src/mezages/sack.py
@@ -70,3 +70,20 @@ class Sack:
             self.__store.setdefault(context_path, dict())
             self.__store[context_path].setdefault(message['kind'], list())
             self.__store[context_path][message['kind']].append(message)
+
+    def merge(self, other: 'Sack', mount_context_path: Optional[str] = None) -> None:
+
+        mount_context_path = ensure_context_path(mount_context_path)
+
+        for context_path, context_store in other.store.items():
+            merged_context_path = (
+                f'{mount_context_path}.{context_path}'
+                if context_path
+                else mount_context_path
+            )
+
+            self.__store.setdefault(merged_context_path, dict())
+
+            for kind, messages in context_store.items():
+                self.__store[merged_context_path].setdefault(kind, list())
+                self.__store[merged_context_path][kind].extend(messages)

--- a/tests/test_sack.py
+++ b/tests/test_sack.py
@@ -20,7 +20,8 @@ class TestStore(BaseCase):
         sack = Sack()
 
         sack.add_messages(['First test message'], 'data')
-        sack.add_messages([{'kind': 'failure', 'summary': 'Second test message'}])
+        sack.add_messages(
+            [{'kind': 'failure', 'summary': 'Second test message'}])
 
         expected_store = getattr(sack, '_Sack__store')
 
@@ -37,7 +38,8 @@ class TestFlat(BaseCase):
         sack = Sack()
 
         sack.add_messages(['First test message'], 'data')
-        sack.add_messages([{'kind': 'failure', 'summary': 'Second test message'}])
+        sack.add_messages(
+            [{'kind': 'failure', 'summary': 'Second test message'}])
 
         self.assertCountEqual(
             sack.flat,
@@ -66,7 +68,8 @@ class TestMount(BaseCase):
 
         self.sack.add_messages(['First test message'], 'data')
 
-        self.sack.add_messages([{'kind': 'failure', 'summary': 'Second test message'}])
+        self.sack.add_messages(
+            [{'kind': 'failure', 'summary': 'Second test message'}])
 
     def test_mount_on_global_path(self):
         '''it returns without updating the store'''
@@ -165,7 +168,8 @@ class TestAddMessages(BaseCase):
 
         self.assertEqual(self.sack.store, dict())
 
-        self.sack.add_messages([{'kind': 'failure', 'summary': 'Second global message'}])
+        self.sack.add_messages(
+            [{'kind': 'failure', 'summary': 'Second global message'}])
 
         self.assertDictDeepEqual(
             self.sack.store,
@@ -253,67 +257,70 @@ class TestMerge(BaseCase):
 
     def setUp(self) -> None:
         self.sack = Sack()
+        self.sack.add_messages(['Initial message'])
 
-    def test_merge_with_global_context(self) -> None:
-        '''it merges other Sack into the global context'''
+    def test_merge_another_sack_without_mount_context_path(self) -> None:
+        '''it merges another sack to the existing sack without mount_context_path'''
 
         other_sack = Sack()
-        other_sack.add_messages(['First test message'], 'first')
-        other_sack.add_messages(
-            [{'kind': 'failure', 'summary': 'Second test message'}], 'second'
-        )
+        other_sack.add_messages(['First message'])
 
         self.sack.merge(other_sack)
 
         self.assertDictDeepEqual(
             self.sack.store,
             {
-                'global.first': {
+                'global': {
                     'notice': [
                         {
-                            'ctx': 'first',
+                            'ctx': 'global',
                             'kind': 'notice',
-                            'summary': 'First test message',
+                            'summary': 'Initial message',
                             'description': None,
-                        }
-                    ]
-                },
-                'global.second': {
-                    'failure': [
+                        },
                         {
-                            'ctx': 'second',
-                            'kind': 'failure',
-                            'summary': 'Second test message',
+                            'ctx': 'global',
+                            'kind': 'notice',
+                            'summary': 'First message',
                             'description': None,
-                        }
+                        },
                     ]
-                },
+                }
             },
         )
 
-    def test_merge_with_custom_context(self) -> None:
-        '''it merges other Sack into a custom context'''
+    def test_merge_another_sack_with_mount_context_path(self) -> None:
+        '''it merges another sack to the existing sack with mount context path'''
 
         other_sack = Sack()
-        other_sack.add_messages(['First test message'], 'data')
-        other_sack.add_messages([{'kind': 'failure', 'summary': 'Second test message'}])
+        other_sack.add_messages(['First test message'])
+        other_sack.add_messages(
+            [{'kind': 'failure', 'summary': 'Second test message'}])
 
-        self.sack.merge(other_sack, mount_context_path='user')
+        self.sack.merge(other_sack, 'user')
 
         self.assertDictDeepEqual(
             self.sack.store,
             {
-                'user.data': {
+                'global': {
                     'notice': [
                         {
-                            'ctx': 'data',
+                            'ctx': 'global',
                             'kind': 'notice',
-                            'summary': 'First test message',
+                            'summary': 'Initial message',
                             'description': None,
                         }
                     ]
                 },
-                'user': {
+                'user.global': {
+                    'notice': [
+                        {
+                            'ctx': 'global',
+                            'kind': 'notice',
+                            'summary': 'First test message',
+                            'description': None,
+                        }
+                    ],
                     'failure': [
                         {
                             'ctx': 'global',
@@ -321,12 +328,12 @@ class TestMerge(BaseCase):
                             'summary': 'Second test message',
                             'description': None,
                         }
-                    ]
+                    ],
                 },
             },
         )
 
-    def test_merge_with_existing_context(self) -> None:
+    def test_merge_another_into_existing_context(self) -> None:
         '''it merges other Sack into an existing context'''
 
         existing_sack = Sack()
@@ -341,7 +348,17 @@ class TestMerge(BaseCase):
         self.assertDictDeepEqual(
             self.sack.store,
             {
-                'global.existing_context': {
+                'global': {
+                    'notice': [
+                        {
+                            'ctx': 'global',
+                            'kind': 'notice',
+                            'summary': 'Initial message',
+                            'description': None,
+                        }
+                    ]
+                },
+                'existing_context': {
                     'notice': [
                         {
                             'ctx': 'existing_context',
@@ -356,6 +373,6 @@ class TestMerge(BaseCase):
                             'description': None,
                         },
                     ]
-                }
+                },
             },
         )

--- a/tests/test_sack.py
+++ b/tests/test_sack.py
@@ -295,7 +295,7 @@ class TestMerge(BaseCase):
         '''it merges other Sack into a custom context'''
 
         other_sack = Sack()
-        other_sack.add_messages(['First test message'], 'first')
+        other_sack.add_messages(['First test message'], 'data')
         other_sack.add_messages([{'kind': 'failure', 'summary': 'Second test message'}])
 
         self.sack.merge(other_sack, mount_context_path='user')
@@ -303,17 +303,17 @@ class TestMerge(BaseCase):
         self.assertDictDeepEqual(
             self.sack.store,
             {
-                'user.first': {
+                'user.data': {
                     'notice': [
                         {
-                            'ctx': 'first',
+                            'ctx': 'data',
                             'kind': 'notice',
                             'summary': 'First test message',
                             'description': None,
                         }
                     ]
                 },
-                'user.global': {
+                'user': {
                     'failure': [
                         {
                             'ctx': 'global',


### PR DESCRIPTION
Implemented `merge` method for `Sack` class:

- Merges messages from another Sack object under a chosen context path.
- Handles new contexts, kinds, and existing ones correctly.
- Added comprehensive unit tests covering various scenarios.